### PR TITLE
Better testing and code organisation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ wheels/
 
 # Virtual environments
 .venv
+.vscode
 site

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This simple package makes it easy to use the new ([`reinit="create_new"`](https://docs.wandb.ai/guides/runs/multiple-runs-per-process/#example-concurrent-processes))
 feature of Weights & Biases (wandb) to create and log to multiple wandb runs in parallel
 
-This, when combined with `jax.vmap`, enables extremely efficient, high-throughput training (**and logging**!) of multiple simultaneous training runs. 
+This, when combined with `jax.vmap`, enables extremely efficient, high-throughput training (**and logging**!) of multiple simultaneous training runs.
 
 - This package provides two simple functions that you can import and use in your own project: `wandb_init` to initialize multiple wandb runs and `wandb_log` to log metrics to them in parallel.
 - A demonstration of how these can be used with jax.vmap can be found in `jax_mnist.py`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@
 This simple package makes it easy to use the new ([`reinit="create_new"`](https://docs.wandb.ai/guides/runs/multiple-runs-per-process/#example-concurrent-processes))
 feature of Weights & Biases (wandb) to create and log to multiple wandb runs in parallel
 
-This, when combined with `jax.vmap`, enables extremely efficient, high-throughput training (**and logging**!) of multiple simultaneous training runs. 
+This, when combined with `jax.vmap`, enables extremely efficient, high-throughput training (**and logging**!) of multiple simultaneous training runs.
 
 - This package provides two simple functions that you can import and use in your own project: `wandb_init` to initialize multiple wandb runs and `wandb_log` to log metrics to them in parallel.
 - A demonstration of how these can be used with jax.vmap can be found in `jax_mnist.py`.

--- a/jax_mnist.py
+++ b/jax_mnist.py
@@ -25,9 +25,6 @@ from typing import Callable
 
 import einops
 import jax
-import jax.experimental
-import jax.experimental.multihost_utils
-import jax.experimental.shard_map
 import jax.numpy as jnp
 import numpy as np
 import rich.logging
@@ -181,7 +178,7 @@ def main():
         rngs, data_rngs, jnp.arange(num_seeds)
     )
     logger.info(
-        f"Final state structure: {rich.pretty.pprint(jax.tree.map(jax.typeof, final_state))}"
+        f"Final state structure:\n{rich.pretty.pretty_repr(jax.tree.map(jax.typeof, final_state))}"
     )
     print(f"{final_test_accs=}")
 

--- a/jax_mnist.py
+++ b/jax_mnist.py
@@ -39,7 +39,8 @@ from jax.example_libraries.optimizers import OptimizerState, Params
 from jax.example_libraries.stax import Dense, LogSoftmax, Relu
 from wandb.sdk.wandb_run import Run
 
-from parallel_wandb.log import NestedSequence, wandb_init, wandb_log
+from parallel_wandb.init import wandb_init
+from parallel_wandb.log import NestedSequence, wandb_log
 
 os.environ["XLA_PYTHON_CLIENT_PREALLOCATE"] = "false"
 

--- a/parallel_wandb/__init__.py
+++ b/parallel_wandb/__init__.py
@@ -1,3 +1,7 @@
 """An example of how to do logging to multiple wandb runs in parallel."""
-from .log import wandb_init, wandb_log, map_fn_and_log_to_wandb
+
+from .init import wandb_init
+from .map_and_log import map_fn_and_log_to_wandb
+from .log import wandb_log
+
 __all__ = ["wandb_init", "wandb_log", "map_fn_and_log_to_wandb"]

--- a/parallel_wandb/example_test.py
+++ b/parallel_wandb/example_test.py
@@ -54,5 +54,6 @@ def test_jax_mnist_example(
         files_in_run_dir = list(run_dir.iterdir())
         assert (run_dir / "logs") in files_in_run_dir
         assert (run_dir / "files") in files_in_run_dir
-        config_file = run_dir / "files" / "config.yaml"
-        assert False, config_file.read_text()
+        # Doesn't seem to be there? Curious.
+        # config_file = run_dir / "files" / "config.yaml"
+        # assert config_file.read_text()

--- a/parallel_wandb/example_test.py
+++ b/parallel_wandb/example_test.py
@@ -1,0 +1,58 @@
+"""Tests that run the examples."""
+
+import functools
+import sys
+from pathlib import Path
+
+import pytest
+import pytest_mock
+import wandb
+
+from parallel_wandb.init import wandb_init
+
+
+def test_jax_mnist_example(
+    monkeypatch: pytest.MonkeyPatch, mocker: pytest_mock.MockFixture, tmp_path: Path
+):
+    """Run the jax_mnist example."""
+    monkeypatch.setenv("WANDB_MODE", "offline")  # Avoid actual online WandB logging during tests
+    monkeypatch.setenv("WANDB_DIR", str(tmp_path))
+
+    _wandb_init = mocker.Mock(spec_set=True, spec=wandb.init, wraps=wandb.init)
+    # mocker.patch("wandb.init", return_value=_wandb_init)
+    import jax_mnist
+
+    # TODO: Problem is that this is stuck as the default in the wandb_init signature,
+    # so patching wandb.init or the module attribute has no effect!
+    monkeypatch.setattr(
+        jax_mnist,
+        wandb_init.__name__,
+        functools.partial(wandb_init, _wandb_init=_wandb_init),
+    )
+
+    # Set command-line arguments
+
+    num_seeds = 4
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [Path(jax_mnist.__file__).name, "--num_epochs", "2", "--num_seeds", str(num_seeds)],
+    )
+    jax_mnist.main()
+
+    _wandb_init.assert_called()
+    assert _wandb_init.call_count == num_seeds
+
+    wandb_dir = tmp_path / "wandb"
+    assert wandb_dir.exists()
+
+    # One offline run per seed.
+    # There's also a `wandb/latest-run` symlink which we ignore.
+    run_dirs = list(f for f in wandb_dir.iterdir() if f.is_dir() and not f.is_symlink())
+    assert len(run_dirs) == num_seeds, run_dirs
+    for run_dir in run_dirs:
+        files_in_run_dir = list(run_dir.iterdir())
+        assert (run_dir / "logs") in files_in_run_dir
+        assert (run_dir / "files") in files_in_run_dir
+        config_file = run_dir / "files" / "config.yaml"
+        assert False, config_file.read_text()

--- a/parallel_wandb/init.py
+++ b/parallel_wandb/init.py
@@ -1,0 +1,155 @@
+# IDEA: only show handles to Jax, put the Run objects in a global variable. (ugly)
+# RUN_OBJECTS: dict[int, Run] = {}
+
+
+import inspect
+import operator
+import os
+import typing
+from collections.abc import Callable, Sequence
+from typing import Any
+
+import numpy as np
+import optree
+import optree.accessor
+import wandb
+from wandb.sdk.wandb_run import Run
+
+from parallel_wandb.log import _merge
+from parallel_wandb.utils import NestedMapping, NestedSequence, is_tracer
+
+
+def wandb_init[**P](
+    stacked_overrides: NestedMapping[str, np.typing.ArrayLike] | None = None,
+    process_index: int | None = None,
+    _wandb_init: Callable[P, Run] = wandb.init,
+    *args: P.args,
+    **kwargs: P.kwargs,
+) -> NestedSequence[Run]:
+    """Initializes multiple wandb runs in parallel.
+
+    The usual args and kwargs to be passed to wandb.init will be overwritten by the (unstacked) values
+    in `stacked_overrides`. The values in `stacked_overrides` should be lists or arrays with the same
+    shape. The shape of the first item in that dict determines the shape of the runs to be created.
+    The stacked arguments are to be passed separately and will override the values from *args and **kwargs.
+
+    For example:
+
+    ```python
+    wandb_init({"name": ["run_1", "run_2", "run_3"], "config": {"seed": [1, 2, 3]}})
+    # This will create three runs like so:
+    np.asarray([
+        wandb.init(name="run_1", config={"seed": 1}, reinit="create_new"),
+        wandb.init(name="run_2", config={"seed": 2}, reinit="create_new"),
+        wandb.init(name="run_3", config={"seed": 3}, reinit="create_new"),
+    ])
+    ```
+
+    This also works with nested arrays:
+
+    ```python
+    wandb_init({"name": [["run_1", "run_2"], ["run_3", "run_4]], "config": {"seed": [[1, 2], [3, 4]]}})
+    # This will create four runs like so:
+    np.asarray([
+        [
+            wandb.init(name="run_1", config={"seed": 1}, reinit="create_new"),
+            wandb.init(name="run_2", config={"seed": 2}, reinit="create_new"),
+        ],
+        [
+            wandb.init(name="run_3", config={"seed": 3}, reinit="create_new"),
+            wandb.init(name="run_4", config={"seed": 4}, reinit="create_new"),
+        ]
+    ])
+    ```
+
+    """
+    if optree.tree_any(optree.tree_map(is_tracer, (stacked_overrides, args, kwargs))):  # type: ignore
+        raise ValueError(
+            "`wandb_init` is not yet compatible with `jax.jit` or `jax.vmap`.\n"
+            "For now, create the runs outside the jitted function, and pass the "
+            "runs as a static argument."
+        )
+
+    # Disable logging if not on the first process.
+    # NOTE: With Jax, it's best to do the same thing on all processes, to avoid deadlocks.
+    # For example, we'd create the dicts and things that are to be logged to wandb, and then pass
+    # them to disabled runs when process_index != 0.
+    # todo: Do we want to enable these goodies by default?
+    if process_index is None and (_slurm_proc_id := os.environ.get("SLURM_PROCID")):
+        process_index = int(_slurm_proc_id)
+
+    if "SLURM_JOB_ID" in os.environ:
+        # Use the job id as the default for the 'group' argument.
+        kwargs.setdefault("group", os.environ["SLURM_JOB_ID"])
+        config = kwargs.setdefault("config", {})
+        assert isinstance(config, dict)
+        # Always useful: Add the SLURM environment variables to the config dict.
+        config.update({k: v for k, v in os.environ.items() if k.startswith("SLURM")})
+
+    # IDEA: Could be interesting to enable logging on other processes if the data is local to them anyway?
+    # (to avoid transferring data to the first node all the time)
+    if (process_index or 0) != 0:
+        kwargs["mode"] = "disabled"
+
+    def _base_case(*args: P.args, **kwargs: P.kwargs) -> Run:
+        kwargs["reinit"] = "create_new"  # Essential: Makes it possible to create multiple runs.
+        return _wandb_init(*args, **kwargs)
+
+    if not stacked_overrides:
+        return np.asanyarray(_base_case(*args, **kwargs))
+
+    stacked_overrides = stacked_overrides or {}
+    _stacked_overrides = typing.cast(Any, stacked_overrides)  # typing bug in optree?
+    accessors, overrides, _overrides_treedef = optree.tree_flatten_with_accessor(
+        _stacked_overrides,
+        is_leaf=lambda v: isinstance(v, (tuple | list | np.ndarray)) or hasattr(v, "shape"),
+    )
+
+    first_override = overrides[0]
+    if not (isinstance(first_override, Sequence) or hasattr(first_override, "shape")):
+        # The overrides are not stacked! (weird!) Do we want to support this?
+        raise NotImplementedError(
+            f"Assuming that all overrides are stacked for now. {first_override=}, {stacked_overrides=}"
+        )
+
+    overrides = list(map(np.asarray, overrides))
+
+    shape = overrides[0].shape  # assumed shared across all overrides.
+    n_runs = int(np.prod(shape))
+    # TODO: signature of `wandb.init` and `_wandb_init` are different during tests, could cause issues!
+    sig = inspect.signature(_wandb_init)
+    base_bound_args = sig.bind_partial(*args, **kwargs)
+    runs = []
+    for run_index in range(n_runs):
+        # Unravel the index to get the position in the grid.
+        grid_pos = np.unravel_index(run_index, shape)
+        # Get the overrides for this run.
+
+        _overrides = typing.cast(Any, overrides)  # typing bug in optree (list isn't a pytree?)
+        overrides_i = optree.tree_map(operator.itemgetter(grid_pos), _overrides)
+
+        override_bound_args = sig.bind_partial(*base_bound_args.args, **base_bound_args.kwargs)
+        # override_args = copy.deepcopy(base_bound_args.args)
+        # override_kwargs = copy.deepcopy(base_bound_args.kwargs)
+
+        override_kwargs = {}
+        for accessor, override in zip(accessors, overrides_i):
+            assert all(isinstance(part, optree.accessor.MappingEntry) for part in accessor), (
+                accessor,
+            )
+            override_kwargs_i = override_kwargs
+            for path in accessor.path[:-1]:
+                override_kwargs_i = override_kwargs_i.setdefault(path, {})
+            override_kwargs_i[accessor.path[-1]] = override
+
+        override_arguments = _merge(
+            override_bound_args.arguments,
+            override_kwargs,
+        )
+        b = sig.bind_partial(
+            **override_arguments,
+        )
+        # Create the run.
+        run = _base_case(*b.args, **b.kwargs)
+        runs.append(run)
+    return np.array(runs).reshape(shape)

--- a/parallel_wandb/init_test.py
+++ b/parallel_wandb/init_test.py
@@ -1,0 +1,104 @@
+import os
+from unittest.mock import Mock
+
+import numpy as np
+import pytest
+import wandb
+
+from parallel_wandb.init import wandb_init
+
+
+@pytest.fixture
+def slurm_env_vars(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch):
+    """Set SLURM environment variables to simulate a slurm job."""
+    env_vars = getattr(request, "param", {"SLURM_JOB_ID": "12345", "SLURM_PROCID": 0})
+    for var, value in env_vars.items():
+        monkeypatch.setenv(var, value)
+    return env_vars
+
+
+@pytest.mark.parametrize(
+    slurm_env_vars.__name__,
+    [
+        {"SLURM_JOB_ID": "12345", "SLURM_PROCID": "0"},
+        {"SLURM_JOB_ID": "12345", "SLURM_PROCID": "1"},
+    ],
+    indirect=True,
+)
+def test_wandb_init_with_slurm_env_vars(slurm_env_vars: dict[str, str]):
+    init = Mock(spec=wandb.init, spec_set=True)
+    run = wandb_init(_wandb_init=init, project="test_project", name="test_name")
+    assert run == np.asanyarray(init.return_value)
+    init.assert_called_once_with(
+        project="test_project",
+        name="test_name",
+        group=slurm_env_vars["SLURM_JOB_ID"],
+        config=slurm_env_vars,
+        reinit="create_new",
+        **({"mode": "disabled"} if slurm_env_vars["SLURM_PROCID"] != "0" else {}),
+    )
+
+
+@pytest.fixture(autouse=True)
+def unset_slurm_env_vars(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch):
+    """Unset SLURM environment variables in case tests are being run in a slurm job.
+
+    The SLURM env vars change some defaults in the `wandb_init` function.
+    """
+    if (_keep_slurm_env_vars := getattr(request, "param", False)) is True:
+        # By parameterizing the fixture indirectly with `True`, that signals that we want to keep
+        # the SLURM env vars during a specific test.
+        # This can be interesting for example when running tests inside a slurm job with
+        # multiple tasks, possibly even multiple nodes!
+        return
+    # Temporarily unset all SLURM environment variables while tests run.
+    for var in os.environ:
+        if var.startswith("SLURM_"):
+            monkeypatch.delenv(var, raising=False)
+
+
+def test_wandb_init():
+    init = Mock(spec=wandb.init, spec_set=True)
+    run = wandb_init(_wandb_init=init, project="test_project", name="test_name")
+    assert run == np.asanyarray(init.return_value)
+    init.assert_called_once_with(project="test_project", name="test_name", reinit="create_new")
+
+
+def test_wandb_init_multiple():
+    init = Mock(spec=wandb.init, spec_set=True)
+    runs = wandb_init(
+        {"name": ["run_0", "run_1"], "config": {"seed": [0, 1]}},
+        _wandb_init=init,
+        project="test_project",
+        name="test_name",
+    )
+    assert isinstance(runs, np.ndarray) and runs.shape == (2,) and runs.dtype == object
+    init.assert_any_call(
+        name="run_0", project="test_project", config={"seed": 0}, reinit="create_new"
+    )
+    init.assert_any_call(
+        name="run_1", project="test_project", config={"seed": 1}, reinit="create_new"
+    )
+    assert init.call_count == 2
+
+
+def test_wandb_init_multiple_with_config():
+    init = Mock(spec=wandb.init, spec_set=True)
+    run = wandb_init(
+        {"config": {"seed": [1, 2, 3]}},
+        _wandb_init=init,
+        project="test_project",
+        name="test_name",
+        config={"bob": 1},
+    )
+    assert isinstance(run, np.ndarray) and run.dtype == object
+    assert run.shape == (3,)
+    init.assert_any_call(
+        name="test_name", project="test_project", config={"seed": 1, "bob": 1}, reinit="create_new"
+    )
+    init.assert_any_call(
+        name="test_name", project="test_project", config={"seed": 2, "bob": 1}, reinit="create_new"
+    )
+    init.assert_any_call(
+        name="test_name", project="test_project", config={"seed": 3, "bob": 1}, reinit="create_new"
+    )

--- a/parallel_wandb/log.py
+++ b/parallel_wandb/log.py
@@ -1,176 +1,18 @@
 """Functions that make it easy to create and log metrics to multiple wandb runs in parallel."""
 
 import functools
-import inspect
 import operator
-import os
-import typing
-from collections.abc import Callable, Sequence
 from logging import getLogger
-from typing import Any, Concatenate, Iterable, Mapping, TypeVar
+from typing import Any
 
 import numpy as np
 import optree
-import optree.accessor
-import wandb
 from optree import PyTree
 from wandb.sdk.wandb_run import Run
 
-T = TypeVar("T")
-K = TypeVar("K")
-V = TypeVar("V")
-type NestedSequence[T] = Sequence[T | NestedSequence[T]]
-type NestedMapping[K, V] = Mapping[K, V | NestedMapping[K, V]]
+from parallel_wandb.utils import NestedSequence, get_step, is_tracer, shape_begins_with, slice
 
 logger = getLogger(__name__)
-
-
-# IDEA: only show handles to Jax, put the Run objects in a global variable. (ugly)
-# RUN_OBJECTS: dict[int, Run] = {}
-
-
-def wandb_init[**P](
-    stacked_overrides: NestedMapping[str, np.typing.ArrayLike] | None = None,
-    process_index: int | None = None,
-    _wandb_init: Callable[P, Run] = wandb.init,
-    *args: P.args,
-    **kwargs: P.kwargs,
-) -> NestedSequence[Run]:
-    """Initializes multiple wandb runs in parallel.
-
-    The usual args and kwargs to be passed to wandb.init will be overwritten by the (unstacked) values
-    in `stacked_overrides`. The values in `stacked_overrides` should be lists or arrays with the same
-    shape. The shape of the first item in that dict determines the shape of the runs to be created.
-    The stacked arguments are to be passed separately and will override the values from *args and **kwargs.
-
-    For example:
-
-    ```python
-    wandb_init({"name": ["run_1", "run_2", "run_3"], "config": {"seed": [1, 2, 3]}})
-    # This will create three runs like so:
-    np.asarray([
-        wandb.init(name="run_1", config={"seed": 1}, reinit="create_new"),
-        wandb.init(name="run_2", config={"seed": 2}, reinit="create_new"),
-        wandb.init(name="run_3", config={"seed": 3}, reinit="create_new"),
-    ])
-    ```
-
-    This also works with nested arrays:
-
-    ```python
-    wandb_init({"name": [["run_1", "run_2"], ["run_3", "run_4]], "config": {"seed": [[1, 2], [3, 4]]}})
-    # This will create four runs like so:
-    np.asarray([
-        [
-            wandb.init(name="run_1", config={"seed": 1}, reinit="create_new"),
-            wandb.init(name="run_2", config={"seed": 2}, reinit="create_new"),
-        ],
-        [
-            wandb.init(name="run_3", config={"seed": 3}, reinit="create_new"),
-            wandb.init(name="run_4", config={"seed": 4}, reinit="create_new"),
-        ]
-    ])
-    ```
-
-    """
-    if optree.tree_any(optree.tree_map(_is_tracer, (stacked_overrides, args, kwargs))):  # type: ignore
-        raise ValueError(
-            "`wandb_init` is not yet compatible with `jax.jit` or `jax.vmap`.\n"
-            "For now, create the runs outside the jitted function, and pass the "
-            "runs as a static argument."
-        )
-
-    # Disable logging if not on the first process.
-    # NOTE: With Jax, it's best to do the same thing on all processes, to avoid deadlocks.
-    # For example, we'd create the dicts and things that are to be logged to wandb, and then pass
-    # them to disabled runs when process_index != 0.
-    # todo: Do we want to enable these goodies by default?
-    if process_index is None and (_slurm_proc_id := os.environ.get("SLURM_PROCID")):
-        process_index = int(_slurm_proc_id)
-
-    if "SLURM_JOB_ID" in os.environ:
-        # Use the job id as the default for the 'group' argument.
-        kwargs.setdefault("group", os.environ["SLURM_JOB_ID"])
-        config = kwargs.setdefault("config", {})
-        assert isinstance(config, dict)
-        # Always useful: Add the SLURM environment variables to the config dict.
-        config.update({k: v for k, v in os.environ.items() if k.startswith("SLURM")})
-
-    # IDEA: Could be interesting to enable logging on other processes if the data is local to them anyway?
-    # (to avoid transferring data to the first node all the time)
-    if (process_index or 0) != 0:
-        kwargs["mode"] = "disabled"
-
-    def _base_case(*args: P.args, **kwargs: P.kwargs) -> Run:
-        kwargs["reinit"] = "create_new"  # Essential: Makes it possible to create multiple runs.
-        return _wandb_init(*args, **kwargs)
-
-    if not stacked_overrides:
-        return np.asanyarray(_base_case(*args, **kwargs))
-
-    stacked_overrides = stacked_overrides or {}
-    _stacked_overrides = typing.cast(Any, stacked_overrides)  # typing bug in optree?
-    accessors, overrides, _overrides_treedef = optree.tree_flatten_with_accessor(
-        _stacked_overrides,
-        is_leaf=lambda v: isinstance(v, (tuple | list | np.ndarray)) or hasattr(v, "shape"),
-    )
-
-    first_override = overrides[0]
-    if not (isinstance(first_override, Sequence) or hasattr(first_override, "shape")):
-        # The overrides are not stacked! (weird!) Do we want to support this?
-        raise NotImplementedError(
-            f"Assuming that all overrides are stacked for now. {first_override=}, {stacked_overrides=}"
-        )
-
-    overrides = list(map(np.asarray, overrides))
-
-    shape = overrides[0].shape  # assumed shared across all overrides.
-    n_runs = int(np.prod(shape))
-
-    sig = inspect.signature(wandb.init)
-    base_bound_args = sig.bind_partial(*args, **kwargs)
-    runs = []
-    for run_index in range(n_runs):
-        # Unravel the index to get the position in the grid.
-        grid_pos = np.unravel_index(run_index, shape)
-        # Get the overrides for this run.
-
-        _overrides = typing.cast(Any, overrides)  # typing bug in optree (list isn't a pytree?)
-        overrides_i = optree.tree_map(operator.itemgetter(grid_pos), _overrides)
-
-        override_bound_args = sig.bind_partial(*base_bound_args.args, **base_bound_args.kwargs)
-        # override_args = copy.deepcopy(base_bound_args.args)
-        # override_kwargs = copy.deepcopy(base_bound_args.kwargs)
-
-        override_kwargs = {}
-        for accessor, override in zip(accessors, overrides_i):
-            assert all(isinstance(part, optree.accessor.MappingEntry) for part in accessor), (
-                accessor,
-            )
-            override_kwargs_i = override_kwargs
-            for path in accessor.path[:-1]:
-                override_kwargs_i = override_kwargs_i.setdefault(path, {})
-            override_kwargs_i[accessor.path[-1]] = override
-
-        override_arguments = _merge(
-            override_bound_args.arguments,
-            override_kwargs,
-        )
-        b = sig.bind_partial(
-            **override_arguments,
-        )
-        # Create the run.
-        run = _base_case(*b.args, **b.kwargs)
-        runs.append(run)
-    return np.array(runs).reshape(shape)
-
-
-def default_run_suffix_fn(grid_pos: tuple[int, ...], grid_shape: tuple[int, ...]) -> str:
-    # Option 1: _i_j_k style
-    # return "_".join(map(str, grid_pos))
-    # Option 2: _index style
-    index = np.arange(0, np.prod(grid_shape)).reshape(grid_shape)[grid_pos]
-    return f"_{index}"
 
 
 def wandb_log(
@@ -192,7 +34,7 @@ def wandb_log(
         metrics_are_stacked = _check_shape_prefix(metrics, wandb_run_array.shape)
 
     # TODO: Probably won't work correctly if only one of `step` or `metrics` is traced.
-    this_is_being_traced = optree.tree_any(optree.tree_map(_is_tracer, (metrics, step)))  # type: ignore
+    this_is_being_traced = optree.tree_any(optree.tree_map(is_tracer, (metrics, step)))  # type: ignore
     this_is_being_vmapped = this_is_being_traced and multiple_runs and metrics_are_stacked is False
     if this_is_being_traced:
         logger.debug(
@@ -236,12 +78,12 @@ def wandb_log(
             # possible to log to a previous step." (https://docs.wandb.ai/ref/python/log/#the-wb-step)
             # This implies that our approach with io_callback(ordered=False) is wrong!
             # However, it does seem to work just fine in practice.. 🤔
-            if not _is_tracer(step):
+            if not is_tracer(step):
                 step = int(step.item())
                 return jax.experimental.io_callback(
                     lambda _metrics: wandb_run.log(_metrics, step=step), (), metrics
                 )
-            if not optree.tree_all(optree.tree_map(_is_tracer, metrics)):
+            if not optree.tree_all(optree.tree_map(is_tracer, metrics)):
                 return jax.experimental.io_callback(
                     lambda _step: wandb_run.log(metrics, step=_step), (), step
                 )
@@ -264,35 +106,22 @@ def wandb_log(
 
     # non-recursive version that indexes using the multi-dimensional metrics.
     _num_runs = np.prod(wandb_run_array.shape)
-    for run_index, wandb_run_i, metrics_i in _slice(
-        wandb_run_array.shape, wandb_run_array, metrics
+    for run_index, wandb_run_i, metrics_i in slice(
+        wandb_run_array.shape,
+        wandb_run_array,
+        metrics,
+        # todo: Make this an argument for a more precise and predictable behaviour?
+        strict=False,
     ):
         assert isinstance(wandb_run_i, Run)
         indexing_tuple = np.unravel_index(run_index, wandb_run_array.shape)
-        # todo: re-enable this use-case: log the same metrics in all runs.
         # if not metrics_are_stacked:
         #     metrics_i = metrics
         # logger.info("Run index: %s, metrics: %s", run_index, jax.tree.map(jax.typeof, metrics))
-        step_i = _get_step(step, indexing_tuple)
+        step_i = get_step(step, indexing_tuple)
         log(wandb_run_i, metrics=metrics_i, step=step_i)
 
     return
-
-
-def _get_step(
-    step: int | np.typing.ArrayLike, indexing_tuple: tuple[int, ...] | tuple[np.intp, ...]
-):
-    if isinstance(step, int) or not hasattr(step, "shape"):
-        return step
-    step = typing.cast(np.typing.NDArray, step)
-    if step.ndim == 0:
-        if _is_tracer(step):
-            # Under jax.jit we can't call .item() on a tracer.
-            # The step will become an int once inside the io_callback.
-            return step
-        return step.item()
-    assert step.ndim == len(indexing_tuple)
-    return step[indexing_tuple]
 
 
 def wandb_log_under_vmap(
@@ -339,130 +168,6 @@ def wandb_log_under_vmap(
     )
 
 
-def map_fn_and_log_to_wandb[**P](
-    wandb_run: Run | NestedSequence[Run],
-    fn: Callable[Concatenate[int, int, P], dict[str, Any]],
-    step: int | np.typing.ArrayLike,
-    run_index: np.typing.NDArray[np.integer] | np.typing.ArrayLike | None = None,
-    *args: P.args,
-    **kwargs: P.kwargs,
-):
-    """Map a function over the (sliced) arg and kwargs and log the results to wandb.
-
-    This is meant to be used to log things like wandb tables, images and such, that
-    need to be created with the data of each run.
-
-    `fn` should be a function that takes a grid position (tuple of ints) in addition
-    to args and kwargs, then return a dictionary of stuff to log to wandb.
-
-    - If `wandb_run` is a single run, the function will be called with an empty
-      tuple as first argument and the args and kwargs unchanged.
-    - If `wandb_run` is a list of runs, the function will be called with the
-      current position in the grid as the first argument, followed by the sliced
-      args and kwargs.
-
-    This works recursively, so the `wandb_run` can be a list of list of wandb runs, etc.
-    """
-    wandb_run_array = np.asanyarray(wandb_run)
-    multiple_runs = wandb_run_array.size > 1
-    this_is_being_traced = optree.tree_any(optree.tree_map(_is_tracer, (wandb_run, step)))  # type: ignore
-
-    def log(
-        wandb_run: Run,
-        step: int | np.typing.ArrayLike,
-        run_index: int,
-        num_runs: int,
-        *args: P.args,
-        **kwargs: P.kwargs,
-    ):
-        """Base case: single run, simple dict of metrics."""
-        if isinstance(step, np.ndarray) or (
-            hasattr(step, "ndim") and callable(getattr(step, "item", None))
-        ):
-            assert step.ndim == 0, step  # type: ignore
-            step = step.item()  # type: ignore
-        metrics = fn(run_index, num_runs, *args, **kwargs)
-        assert isinstance(step, int), step
-        wandb_run.log(metrics, step=step)
-
-    if not multiple_runs:
-        wandb_run = wandb_run if isinstance(wandb_run, Run) else wandb_run_array.item()
-        assert isinstance(wandb_run, Run)
-        if this_is_being_traced:
-            import jax.experimental  # type: ignore
-
-            assert _is_tracer(step), "assuming step is also a tracer for now."
-            return jax.experimental.io_callback(
-                lambda _step, *_args, **_kwargs: log(wandb_run, _step, 0, 1, *_args, **_kwargs),
-                (),
-                step,
-                *args,
-                **kwargs,
-            )
-        return log(wandb_run, step, 0, 1, *args, **kwargs)
-
-    num_runs = wandb_run_array.size
-    for run_index, wandb_run_i, args_i, kwargs_i in _slice(
-        wandb_run_array.shape, wandb_run_array, args, kwargs
-    ):
-        indexing_tuple = np.unravel_index(run_index, wandb_run_array.shape)
-        step_i = _get_step(step, indexing_tuple)
-        if this_is_being_traced:
-            import jax.experimental  # type: ignore
-
-            assert _is_tracer(step_i), "assuming step is also a tracer for now."
-            jax.experimental.io_callback(
-                lambda _step, *_args_i, **_kwargs_i: log(
-                    wandb_run_i, _step, run_index, num_runs, *_args_i, **_kwargs_i
-                ),
-                (),
-                step_i,
-                *args_i,
-                *kwargs_i,
-            )
-        else:
-            log(wandb_run_i, step_i, run_index, num_runs, *args_i, **kwargs_i)
-    return
-    # Everything is a tracer.
-    # TODO: actually, part of the metrics could be tracers, and part not.
-
-    def log_fn(
-        wandb_run: Run,
-        step: int,
-        run_index: int,
-        num_runs: int,
-        *args: P.args,
-        **kwargs: P.kwargs,
-    ):
-        metrics = fn(run_index, num_runs, *args, **kwargs)
-        # Base case: single run, single metric.
-        logger.debug("Logging to wandb run %s: metrics=%s step=%s", wandb_run.name, metrics, step)
-        wandb_run.log(metrics, step=step)
-        return
-
-    for run_index, wandb_run_i, args_i, kwargs_i in _slice(
-        wandb_run_array.shape, wandb_run_array, args, kwargs
-    ):
-        indexing_tuple = np.unravel_index(run_index, wandb_run_array.shape)
-        step_i = _get_step(step, indexing_tuple)
-        log_fn(wandb_run_i, step_i, run_index, wandb_run_array.size, *args_i, **kwargs_i)
-
-
-def _slice[*Ts](run_grid_shape: tuple[int, ...], *args: *Ts) -> Iterable[tuple[int, *Ts]]:
-    """Yields the sliced args and kwargs for each run in the grid."""
-    num_runs = int(np.prod(run_grid_shape))
-    for run_index in range(num_runs):
-        indexing_tuple = np.unravel_index(run_index, run_grid_shape)
-        args_i = optree.tree_map(
-            lambda v: operator.itemgetter(indexing_tuple)(v)
-            if _shape_begins_with(v, run_grid_shape)
-            else v,  # duplicate the metric if it doesn't have the right shape prefix?
-            args,
-        )  # type: ignore
-        # kwargs_i = optree.tree_map(operator.itemgetter(indexing_tuple), kwargs)  # type: ignore
-        yield (run_index,) + args_i
-
-
 def _merge[T](v1: T, v2: T) -> T:
     """Merge two values (maybe dictionaries) recursively."""
     if not isinstance(v1, dict):
@@ -480,62 +185,7 @@ def _merge[T](v1: T, v2: T) -> T:
     return result  # type: ignore
 
 
-def _is_tracer(v: Any) -> bool:
-    if "Tracer" in type(v).__name__:
-        return True
-    return False
-
-
 def _check_shape_prefix(metrics: PyTree[Any], shape: tuple[int, ...]) -> bool:
     """Returns `True` if all the entries in `metrics` have a shape that begins with `shape`."""
-    fn = functools.partial(_shape_begins_with, prefix=shape)
+    fn = functools.partial(shape_begins_with, prefix=shape)
     return optree.tree_all(optree.tree_map(fn, metrics))
-
-
-def _shape_begins_with(metric: np.typing.ArrayLike, prefix: tuple[int, ...]) -> bool:
-    """Returns `True` if `metric` has a shape that begins with `prefix`."""
-    if not hasattr(metric, "shape"):
-        return False
-    metric = typing.cast(np.typing.NDArray, metric)
-    return metric.shape[: len(prefix)] == prefix
-
-
-def _assert_shape_prefix[M: Mapping[str, Any]](metrics: M, shape: tuple[int, ...]) -> M:
-    def _check_shape(metric: np.typing.ArrayLike):
-        if not hasattr(metric, "shape"):
-            return False
-        metric = typing.cast(np.typing.NDArray, metric)
-        if not metric.shape[: len(shape)] == shape:
-            raise ValueError(
-                f"Metric {metric} has shape {metric.shape}, but expected its "
-                f"shape to begin with {shape}"
-            )
-        return metric
-
-    return optree.tree_map(_check_shape, metrics)
-
-
-def _array_first_value(array: np.typing.ArrayLike, jittable: bool = False) -> int:
-    # Assume it's the same timestep for all runs, otherwise things might be tricky.
-    if isinstance(array, int):
-        return array
-    if jittable:
-        if array.ndim == 0:
-            return array
-        return array.flatten()[0]  # type: ignore
-    else:
-        if array.ndim == 0:
-            return array
-        step = array.flatten()[0].item()
-        return step
-
-
-# def getitem(v, i: int | tuple[int, ...] | slice | jax.Array | np.ndarray):
-#     if isinstance(v, jax.Array):
-#         # NotImplementedError: dynamic_slice on sharded dims where out dim (1) is not
-#         # divisible by mesh axes (2) with spec (seed) is not implemented.
-#         # No idea if this will work :(
-#         return v[i]
-#         return v.at[i].get(out_sharding=jax.sharding.PartitionSpec())  # type: ignore
-#         # return jax.experimental.multihost_utils.process_allgather(v)[i]
-#     return v[i]

--- a/parallel_wandb/log.py
+++ b/parallel_wandb/log.py
@@ -112,7 +112,8 @@ def wandb_log(
         wandb_run_array,
         metrics,
         # todo: Make this an argument for a more precise and predictable behaviour?
-        strict=False,
+        # strict=False,
+        strict=(not same_metrics_for_all_runs) if same_metrics_for_all_runs is not None else True,
     ):
         assert isinstance(wandb_run_i, Run)
         indexing_tuple = np.unravel_index(run_index, wandb_run_array.shape)

--- a/parallel_wandb/log.py
+++ b/parallel_wandb/log.py
@@ -453,7 +453,12 @@ def _slice[*Ts](run_grid_shape: tuple[int, ...], *args: *Ts) -> Iterable[tuple[i
     num_runs = int(np.prod(run_grid_shape))
     for run_index in range(num_runs):
         indexing_tuple = np.unravel_index(run_index, run_grid_shape)
-        args_i = optree.tree_map(operator.itemgetter(indexing_tuple), args)  # type: ignore
+        args_i = optree.tree_map(
+            lambda v: operator.itemgetter(indexing_tuple)(v)
+            if _shape_begins_with(v, run_grid_shape)
+            else v,  # duplicate the metric if it doesn't have the right shape prefix?
+            args,
+        )  # type: ignore
         # kwargs_i = optree.tree_map(operator.itemgetter(indexing_tuple), kwargs)  # type: ignore
         yield (run_index,) + args_i
 

--- a/parallel_wandb/log_test.py
+++ b/parallel_wandb/log_test.py
@@ -26,7 +26,14 @@ def test_wandb_log_multiple():
 
 def test_wandb_log_same_metrics_in_multiple_runs():
     fake_runs = [mock_run(), mock_run()]
-    wandb_log(fake_runs, {"a": np.asarray([1])}, step=1, metrics_are_stacked=False)
+
+    # TODO: Should we let indexing errors be raised if we don't set the flag?
+    with pytest.raises(IndexError):
+        wandb_log(fake_runs, {"a": np.asarray([1])}, step=1, same_metrics_for_all_runs=False)
+        fake_runs[0].log.assert_called_once_with({"a": 1}, step=1)
+        fake_runs[1].log.assert_called_once_with({"a": 1}, step=1)
+
+    wandb_log(fake_runs, {"a": np.asarray([1])}, step=1, same_metrics_for_all_runs=False)
     fake_runs[0].log.assert_called_once_with({"a": 1}, step=1)
     fake_runs[1].log.assert_called_once_with({"a": 1}, step=1)
 

--- a/parallel_wandb/log_test.py
+++ b/parallel_wandb/log_test.py
@@ -1,109 +1,10 @@
-import os
-import unittest.mock
 from unittest.mock import Mock
 
 import numpy as np
 import pytest
-import wandb
 from wandb.sdk.wandb_run import Run
 
-from .log import NestedSequence, map_fn_and_log_to_wandb, wandb_init, wandb_log
-
-
-def test_wandb_init():
-    init = Mock(spec=wandb.init, spec_set=True)
-    run = wandb_init(_wandb_init=init, project="test_project", name="test_name")
-    assert run == np.asanyarray(init.return_value)
-    init.assert_called_once_with(project="test_project", name="test_name", reinit="create_new")
-
-
-@pytest.fixture(autouse=True)
-def unset_slurm_env_vars(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch):
-    """Unset SLURM environment variables in case tests are being run in a slurm job.
-
-    The SLURM env vars change some defaults in the `wandb_init` function.
-    """
-    if (_keep_slurm_env_vars := getattr(request, "param", False)) is True:
-        # By parameterizing the fixture indirectly with `True`, that signals that we want to keep
-        # the SLURM env vars during a specific test.
-        # This can be interesting for example when running tests inside a slurm job with
-        # multiple tasks, possibly even multiple nodes!
-        return
-    # Temporarily unset all SLURM environment variables while tests run.
-    for var in os.environ:
-        if var.startswith("SLURM_"):
-            monkeypatch.delenv(var, raising=False)
-
-
-@pytest.fixture
-def slurm_env_vars(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch):
-    """Set SLURM environment variables to simulate a slurm job."""
-    env_vars = getattr(request, "param", {"SLURM_JOB_ID": "12345", "SLURM_PROCID": 0})
-    for var, value in env_vars.items():
-        monkeypatch.setenv(var, value)
-    return env_vars
-
-
-@pytest.mark.parametrize(
-    slurm_env_vars.__name__,
-    [
-        {"SLURM_JOB_ID": "12345", "SLURM_PROCID": "0"},
-        {"SLURM_JOB_ID": "12345", "SLURM_PROCID": "1"},
-    ],
-    indirect=True,
-)
-def test_wandb_init_with_slurm_env_vars(slurm_env_vars: dict[str, str]):
-    init = Mock(spec=wandb.init, spec_set=True)
-    run = wandb_init(_wandb_init=init, project="test_project", name="test_name")
-    assert run == np.asanyarray(init.return_value)
-    init.assert_called_once_with(
-        project="test_project",
-        name="test_name",
-        group=slurm_env_vars["SLURM_JOB_ID"],
-        config=slurm_env_vars,
-        reinit="create_new",
-        **({"mode": "disabled"} if slurm_env_vars["SLURM_PROCID"] != "0" else {}),
-    )
-
-
-def test_wandb_init_multiple():
-    init = Mock(spec=wandb.init, spec_set=True)
-    runs = wandb_init(
-        {"name": ["run_0", "run_1"], "config": {"seed": [0, 1]}},
-        _wandb_init=init,
-        project="test_project",
-        name="test_name",
-    )
-    assert isinstance(runs, np.ndarray) and runs.shape == (2,) and runs.dtype == object
-    init.assert_any_call(
-        name="run_0", project="test_project", config={"seed": 0}, reinit="create_new"
-    )
-    init.assert_any_call(
-        name="run_1", project="test_project", config={"seed": 1}, reinit="create_new"
-    )
-    assert init.call_count == 2
-
-
-def test_wandb_init_multiple_with_config():
-    init = Mock(spec=wandb.init, spec_set=True)
-    run = wandb_init(
-        {"config": {"seed": [1, 2, 3]}},
-        _wandb_init=init,
-        project="test_project",
-        name="test_name",
-        config={"bob": 1},
-    )
-    assert isinstance(run, np.ndarray) and run.dtype == object
-    assert run.shape == (3,)
-    init.assert_any_call(
-        name="test_name", project="test_project", config={"seed": 1, "bob": 1}, reinit="create_new"
-    )
-    init.assert_any_call(
-        name="test_name", project="test_project", config={"seed": 2, "bob": 1}, reinit="create_new"
-    )
-    init.assert_any_call(
-        name="test_name", project="test_project", config={"seed": 3, "bob": 1}, reinit="create_new"
-    )
+from .log import wandb_log
 
 
 def mock_run():
@@ -152,19 +53,23 @@ def test_wandb_log_with_different_steps_per_run():
     fake_runs[1][2].log.assert_called_once_with({"a": 5}, step=15)
 
 
-def test_wandb_log_with_vmap():
-    # TODO:
+def test_wandb_log_with_vmap_needs_run_index_arg():
     fake_runs = [mock_run(), mock_run(), mock_run()]
     import jax
     import jax.numpy as jnp
 
+    def _fn1(x):
+        wandb_log(fake_runs, {"a": x}, step=x)
+        return x + 1
+
     with pytest.raises(ValueError, match="need to pass the `run_index` argument"):
+        _ = jax.vmap(_fn1)(jnp.arange(3))
 
-        def _fn1(x):
-            wandb_log(fake_runs, {"a": x}, step=x)
-            return x + 1
 
-        outs = jax.vmap(_fn1)(jnp.arange(3))
+def test_wandb_log_with_vmap():
+    fake_runs = [mock_run(), mock_run(), mock_run()]
+    import jax
+    import jax.numpy as jnp
 
     def _fn(x, run_index: jax.Array):
         wandb_log(fake_runs, {"a": x}, step=x, run_index=run_index)
@@ -175,112 +80,3 @@ def test_wandb_log_with_vmap():
     fake_runs[0].log.assert_called_once_with({"a": jnp.array(0, dtype=jnp.int32)}, step=0)
     fake_runs[1].log.assert_called_once_with({"a": jnp.array(10, dtype=jnp.int32)}, step=10)
     fake_runs[2].log.assert_called_once_with({"a": jnp.array(20, dtype=jnp.int32)}, step=20)
-
-
-@pytest.mark.parametrize("jit", [False, True])
-def test_map_and_log_to_wandb(jit: bool):
-    import jax
-    import jax.numpy as jnp
-
-    wandb_Image = Mock(spec=wandb.Image, spec_set=True, wraps=wandb.Image)
-
-    def _make_image(rng: jax.Array):
-        return jax.random.uniform(
-            rng,
-            (32, 32, 3),
-            minval=0,
-            maxval=256,
-        ).astype(jnp.uint8)
-
-    def _log_image(run_index: int, total_runs: int, data):
-        assert isinstance(data, jax.Array)
-        # This should NEVER be a tracer!
-        # We want this to be called as an io_callback.
-        # EXCEPT if MAYBE, doing `jax.device_get` here signals to jax.jit
-        # to somehow do the rest of this with a new object every time?
-        assert "Tracer" not in type(data).__name__
-        return {
-            "image": wandb_Image(
-                jax.device_get(data), caption=f"Run index {run_index} out of {total_runs}"
-            )
-        }
-
-    def training_step(
-        rng: jax.Array,
-        step: jax.Array,
-        *,
-        wandb_run: Run | NestedSequence[Run],
-        run_index: jax.Array | None = None,
-    ):
-        image_data = _make_image(rng)
-        map_fn_and_log_to_wandb(
-            wandb_run,
-            step=step,
-            fn=_log_image,
-            data=image_data,
-            run_index=run_index,
-        )
-        return image_data
-
-    if jit:
-        training_step = jax.jit(training_step, static_argnames=["wandb_run"])
-
-    fake_run = mock_run()
-    training_step(
-        jax.random.key(0),
-        step=jnp.asarray(0),
-        # run_index=jnp.arange(0),
-        wandb_run=fake_run,
-    )
-    training_step(
-        jax.random.key(1),
-        step=jnp.asarray(1),
-        # run_index=jnp.arange(0),
-        wandb_run=fake_run,
-    )
-    assert len(fake_run.log.call_args) == 2
-    assert wandb_Image.call_count == 2
-    fake_run.log.assert_any_call(
-        {
-            "image": unittest.mock.ANY,
-        },
-        step=0,
-    )
-    fake_run.log.assert_any_call(
-        {
-            "image": unittest.mock.ANY,
-        },
-        step=1,
-    )
-    if fake_run.log.call_args_list[0].kwargs["step"] == 0:
-        # Callback with logs of first step came in first
-        np.testing.assert_array_equal(
-            # Seems like using an io callback adds an extra leading dimension?
-            jnp.expand_dims(jax.device_get(_make_image(jax.random.key(0))), 0),
-            wandb_Image.call_args_list[0][0],
-        )
-        np.testing.assert_array_equal(
-            jnp.expand_dims(jax.device_get(_make_image(jax.random.key(1))), 0),
-            wandb_Image.call_args_list[1][0],
-        )
-    else:
-        raise NotImplementedError("BAD, metrics were logged in wrong order within a single run.")
-        #  Callback with logs of second step came in first?
-        # TODO: Wandb apparently doesn't support this!
-        np.testing.assert_array_equal(
-            jax.device_get(_make_image(jax.random.key(0))),
-            wandb_Image.call_args_list[0][0],
-        )
-        np.testing.assert_array_equal(
-            jax.device_get(_make_image(jax.random.key(1))),
-            wandb_Image.call_args_list[1][0],
-        )
-
-    # wandb_Image.assert_any_call(
-    #     jax.device_get(_make_image(jax.random.key(0))),
-    #     caption="Run index 0 out of 1",
-    # )
-    # wandb_Image.assert_any_call(
-    #     jax.device_get(_make_image(jax.random.key(1))),
-    #     caption="Run index 0 out of 1",
-    # )

--- a/parallel_wandb/log_test.py
+++ b/parallel_wandb/log_test.py
@@ -1,4 +1,5 @@
 import os
+import unittest.mock
 from unittest.mock import Mock
 
 import numpy as np
@@ -6,7 +7,7 @@ import pytest
 import wandb
 from wandb.sdk.wandb_run import Run
 
-from .log import wandb_init, wandb_log
+from .log import NestedSequence, map_fn_and_log_to_wandb, wandb_init, wandb_log
 
 
 def test_wandb_init():
@@ -17,11 +18,18 @@ def test_wandb_init():
 
 
 @pytest.fixture(autouse=True)
-def unset_slurm_env_vars(monkeypatch: pytest.MonkeyPatch):
+def unset_slurm_env_vars(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch):
     """Unset SLURM environment variables in case tests are being run in a slurm job.
 
     The SLURM env vars change some defaults in the `wandb_init` function.
     """
+    if (_keep_slurm_env_vars := getattr(request, "param", False)) is True:
+        # By parameterizing the fixture indirectly with `True`, that signals that we want to keep
+        # the SLURM env vars during a specific test.
+        # This can be interesting for example when running tests inside a slurm job with
+        # multiple tasks, possibly even multiple nodes!
+        return
+    # Temporarily unset all SLURM environment variables while tests run.
     for var in os.environ:
         if var.startswith("SLURM_"):
             monkeypatch.delenv(var, raising=False)
@@ -160,3 +168,112 @@ def test_wandb_log_with_vmap():
     fake_runs[0].log.assert_called_once_with({"a": jnp.array(0, dtype=jnp.int32)}, step=0)
     fake_runs[1].log.assert_called_once_with({"a": jnp.array(10, dtype=jnp.int32)}, step=10)
     fake_runs[2].log.assert_called_once_with({"a": jnp.array(20, dtype=jnp.int32)}, step=20)
+
+
+@pytest.mark.parametrize("jit", [False, True])
+def test_map_and_log_to_wandb(jit: bool):
+    import jax
+    import jax.numpy as jnp
+
+    wandb_Image = Mock(spec=wandb.Image, spec_set=True, wraps=wandb.Image)
+
+    def _make_image(rng: jax.Array):
+        return jax.random.uniform(
+            rng,
+            (32, 32, 3),
+            minval=0,
+            maxval=256,
+        ).astype(jnp.uint8)
+
+    def _log_image(run_index: int, total_runs: int, data):
+        assert isinstance(data, jax.Array)
+        # This should NEVER be a tracer!
+        # We want this to be called as an io_callback.
+        # EXCEPT if MAYBE, doing `jax.device_get` here signals to jax.jit
+        # to somehow do the rest of this with a new object every time?
+        assert "Tracer" not in type(data).__name__
+        return {
+            "image": wandb_Image(
+                jax.device_get(data), caption=f"Run index {run_index} out of {total_runs}"
+            )
+        }
+
+    def training_step(
+        rng: jax.Array,
+        step: jax.Array,
+        *,
+        wandb_run: Run | NestedSequence[Run],
+        run_index: jax.Array | None = None,
+    ):
+        image_data = _make_image(rng)
+        map_fn_and_log_to_wandb(
+            wandb_run,
+            step=step,
+            fn=_log_image,
+            data=image_data,
+            run_index=run_index,
+        )
+        return image_data
+
+    if jit:
+        training_step = jax.jit(training_step, static_argnames=["wandb_run"])
+
+    fake_run = mock_run()
+    training_step(
+        jax.random.key(0),
+        step=jnp.asarray(0),
+        # run_index=jnp.arange(0),
+        wandb_run=fake_run,
+    )
+    training_step(
+        jax.random.key(1),
+        step=jnp.asarray(1),
+        # run_index=jnp.arange(0),
+        wandb_run=fake_run,
+    )
+    assert len(fake_run.log.call_args) == 2
+    assert wandb_Image.call_count == 2
+    fake_run.log.assert_any_call(
+        {
+            "image": unittest.mock.ANY,
+        },
+        step=0,
+    )
+    fake_run.log.assert_any_call(
+        {
+            "image": unittest.mock.ANY,
+        },
+        step=1,
+    )
+    if fake_run.log.call_args_list[0].kwargs["step"] == 0:
+        # Callback with logs of first step came in first
+        np.testing.assert_array_equal(
+            # Seems like using an io callback adds an extra leading dimension?
+            jnp.expand_dims(jax.device_get(_make_image(jax.random.key(0))), 0),
+            wandb_Image.call_args_list[0][0],
+        )
+        np.testing.assert_array_equal(
+            jnp.expand_dims(jax.device_get(_make_image(jax.random.key(1))), 0),
+            wandb_Image.call_args_list[1][0],
+        )
+    else:
+        raise NotImplementedError("BAD, metrics were logged in wrong order within a single run.")
+        #  Callback with logs of second step came in first?
+        # TODO: Wandb apparently doesn't support this!
+        np.testing.assert_array_equal(
+            jax.device_get(_make_image(jax.random.key(0))),
+            wandb_Image.call_args_list[0][0],
+        )
+        np.testing.assert_array_equal(
+            jax.device_get(_make_image(jax.random.key(1))),
+            wandb_Image.call_args_list[1][0],
+        )
+
+    # wandb_Image.assert_any_call(
+    #     jax.device_get(_make_image(jax.random.key(0))),
+    #     caption="Run index 0 out of 1",
+    # )
+    # wandb_Image.assert_any_call(
+    #     jax.device_get(_make_image(jax.random.key(1))),
+    #     caption="Run index 0 out of 1",
+    # )

--- a/parallel_wandb/log_test.py
+++ b/parallel_wandb/log_test.py
@@ -123,6 +123,13 @@ def test_wandb_log_multiple():
     fake_runs[1].log.assert_called_once_with({"a": 2}, step=1)
 
 
+def test_wandb_log_same_metrics_in_multiple_runs():
+    fake_runs = [mock_run(), mock_run()]
+    wandb_log(fake_runs, {"a": np.asarray([1])}, step=1, metrics_are_stacked=False)
+    fake_runs[0].log.assert_called_once_with({"a": 1}, step=1)
+    fake_runs[1].log.assert_called_once_with({"a": 1}, step=1)
+
+
 def test_wandb_log_multiple_2d():
     fake_runs = [[mock_run(), mock_run(), mock_run()], [mock_run(), mock_run(), mock_run()]]
     wandb_log(fake_runs, {"a": np.arange(6).reshape(2, 3)}, step=np.asarray(1))

--- a/parallel_wandb/log_test.py
+++ b/parallel_wandb/log_test.py
@@ -28,12 +28,14 @@ def test_wandb_log_same_metrics_in_multiple_runs():
     fake_runs = [mock_run(), mock_run()]
 
     # TODO: Should we let indexing errors be raised if we don't set the flag?
-    with pytest.raises(IndexError):
-        wandb_log(fake_runs, {"a": np.asarray([1])}, step=1, same_metrics_for_all_runs=False)
-        fake_runs[0].log.assert_called_once_with({"a": 1}, step=1)
-        fake_runs[1].log.assert_called_once_with({"a": 1}, step=1)
+    with pytest.raises((IndexError, TypeError)):
+        wandb_log(fake_runs, {"a": 1, "b": np.arange(2)}, step=1, same_metrics_for_all_runs=False)
+        fake_runs[0].log.assert_called_once_with({"a": 1, "b": np.arange(2)}, step=1)
+        fake_runs[1].log.assert_called_once_with({"a": 1, "b": np.arange(2)}, step=1)
 
-    wandb_log(fake_runs, {"a": np.asarray([1])}, step=1, same_metrics_for_all_runs=False)
+    for _mock in fake_runs:
+        _mock.reset_mock()
+    wandb_log(fake_runs, {"a": np.asarray([1])}, step=1, same_metrics_for_all_runs=True)
     fake_runs[0].log.assert_called_once_with({"a": 1}, step=1)
     fake_runs[1].log.assert_called_once_with({"a": 1}, step=1)
 

--- a/parallel_wandb/map_and_log.py
+++ b/parallel_wandb/map_and_log.py
@@ -1,0 +1,117 @@
+from collections.abc import Callable
+from typing import Any, Concatenate
+
+import numpy as np
+import optree
+from wandb.sdk.wandb_run import Run
+
+from parallel_wandb.utils import NestedSequence, get_step, is_tracer, slice
+
+
+def map_fn_and_log_to_wandb[**P](
+    wandb_run: Run | NestedSequence[Run],
+    fn: Callable[Concatenate[int, int, P], dict[str, Any]],
+    step: int | np.typing.ArrayLike,
+    run_index: np.typing.NDArray[np.integer] | np.typing.ArrayLike | None = None,
+    *args: P.args,
+    **kwargs: P.kwargs,
+):
+    """Map a function over the (sliced) arg and kwargs and log the results to wandb.
+
+    This is meant to be used to log things like wandb tables, images and such, that
+    need to be created with the data of each run.
+
+    `fn` should be a function that takes a grid position (tuple of ints) in addition
+    to args and kwargs, then return a dictionary of stuff to log to wandb.
+
+    - If `wandb_run` is a single run, the function will be called with an empty
+      tuple as first argument and the args and kwargs unchanged.
+    - If `wandb_run` is a list of runs, the function will be called with the
+      current position in the grid as the first argument, followed by the sliced
+      args and kwargs.
+
+    This works recursively, so the `wandb_run` can be a list of list of wandb runs, etc.
+    """
+    wandb_run_array = np.asanyarray(wandb_run)
+    multiple_runs = wandb_run_array.size > 1
+    this_is_being_traced = optree.tree_any(optree.tree_map(is_tracer, (wandb_run, step)))  # type: ignore
+
+    def log(
+        wandb_run: Run,
+        step: int | np.typing.ArrayLike,
+        run_index: int,
+        num_runs: int,
+        *args: P.args,
+        **kwargs: P.kwargs,
+    ):
+        """Base case: single run, simple dict of metrics."""
+        if isinstance(step, np.ndarray) or (
+            hasattr(step, "ndim") and callable(getattr(step, "item", None))
+        ):
+            assert step.ndim == 0, step  # type: ignore
+            step = step.item()  # type: ignore
+        metrics = fn(run_index, num_runs, *args, **kwargs)
+        assert isinstance(step, int), step
+        wandb_run.log(metrics, step=step)
+
+    if not multiple_runs:
+        wandb_run = wandb_run if isinstance(wandb_run, Run) else wandb_run_array.item()
+        assert isinstance(wandb_run, Run)
+        if this_is_being_traced:
+            import jax.experimental  # type: ignore
+
+            assert is_tracer(step), "assuming step is also a tracer for now."
+            return jax.experimental.io_callback(
+                lambda _step, *_args, **_kwargs: log(wandb_run, _step, 0, 1, *_args, **_kwargs),
+                (),
+                step,
+                *args,
+                **kwargs,
+            )
+        return log(wandb_run, step, 0, 1, *args, **kwargs)
+
+    num_runs = wandb_run_array.size
+    for run_index, wandb_run_i, args_i, kwargs_i in slice(
+        wandb_run_array.shape, wandb_run_array, args, kwargs
+    ):
+        indexing_tuple = np.unravel_index(run_index, wandb_run_array.shape)
+        step_i = get_step(step, indexing_tuple)
+        if this_is_being_traced:
+            import jax.experimental  # type: ignore
+
+            assert is_tracer(step_i), "assuming step is also a tracer for now."
+            jax.experimental.io_callback(
+                lambda _step, *_args_i, **_kwargs_i: log(
+                    wandb_run_i, _step, run_index, num_runs, *_args_i, **_kwargs_i
+                ),
+                (),
+                step_i,
+                *args_i,
+                *kwargs_i,
+            )
+        else:
+            log(wandb_run_i, step_i, run_index, num_runs, *args_i, **kwargs_i)
+    return
+    # Everything is a tracer.
+    # TODO: actually, part of the metrics could be tracers, and part not.
+
+    def log_fn(
+        wandb_run: Run,
+        step: int,
+        run_index: int,
+        num_runs: int,
+        *args: P.args,
+        **kwargs: P.kwargs,
+    ):
+        metrics = fn(run_index, num_runs, *args, **kwargs)
+        # Base case: single run, single metric.
+        logger.debug("Logging to wandb run %s: metrics=%s step=%s", wandb_run.name, metrics, step)
+        wandb_run.log(metrics, step=step)
+        return
+
+    for run_index, wandb_run_i, args_i, kwargs_i in slice(
+        wandb_run_array.shape, wandb_run_array, args, kwargs
+    ):
+        indexing_tuple = np.unravel_index(run_index, wandb_run_array.shape)
+        step_i = get_step(step, indexing_tuple)
+        log_fn(wandb_run_i, step_i, run_index, wandb_run_array.size, *args_i, **kwargs_i)

--- a/parallel_wandb/map_and_log.py
+++ b/parallel_wandb/map_and_log.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import Callable
 from typing import Any, Concatenate
 
@@ -6,6 +7,8 @@ import optree
 from wandb.sdk.wandb_run import Run
 
 from parallel_wandb.utils import NestedSequence, get_step, is_tracer, slice
+
+logger = logging.getLogger(__name__)
 
 
 def map_fn_and_log_to_wandb[**P](

--- a/parallel_wandb/map_and_log_test.py
+++ b/parallel_wandb/map_and_log_test.py
@@ -1,0 +1,111 @@
+import unittest.mock
+from unittest.mock import Mock
+
+import jax
+import numpy as np
+import pytest
+import wandb
+from wandb.sdk.wandb_run import Run
+
+from parallel_wandb.log import NestedSequence
+from parallel_wandb.log_test import mock_run
+from parallel_wandb.map_and_log import map_fn_and_log_to_wandb
+
+
+@pytest.mark.parametrize("jit", [False, True])
+def test_map_and_log_to_wandb(jit: bool):
+    import jax.numpy as jnp
+
+    wandb_Image = Mock(spec=wandb.Image, spec_set=True, wraps=wandb.Image)
+
+    def _make_image(rng: jax.Array):
+        return jax.random.uniform(
+            rng,
+            (32, 32, 3),
+            minval=0,
+            maxval=256,
+        ).astype(jnp.uint8)
+
+    def _log_image(run_index: int, total_runs: int, data):
+        assert isinstance(data, jax.Array)
+        # This should NEVER be a tracer!
+        # We want this to be called as an io_callback.
+        # EXCEPT if MAYBE, doing `jax.device_get` here signals to jax.jit
+        # to somehow do the rest of this with a new object every time?
+        assert "Tracer" not in type(data).__name__
+        return {
+            "image": wandb_Image(
+                jax.device_get(data), caption=f"Run index {run_index} out of {total_runs}"
+            )
+        }
+
+    def training_step(
+        rng: jax.Array,
+        step: jax.Array,
+        *,
+        wandb_run: Run | NestedSequence[Run],
+        run_index: jax.Array | None = None,
+    ):
+        image_data = _make_image(rng)
+        map_fn_and_log_to_wandb(
+            wandb_run,
+            step=step,
+            fn=_log_image,
+            data=image_data,
+            run_index=run_index,
+        )
+        return image_data
+
+    if jit:
+        training_step = jax.jit(training_step, static_argnames=["wandb_run"])
+
+    fake_run = mock_run()
+    training_step(
+        jax.random.key(0),
+        step=jnp.asarray(0),
+        # run_index=jnp.arange(0),
+        wandb_run=fake_run,
+    )
+    training_step(
+        jax.random.key(1),
+        step=jnp.asarray(1),
+        # run_index=jnp.arange(0),
+        wandb_run=fake_run,
+    )
+    assert len(fake_run.log.call_args) == 2
+    assert wandb_Image.call_count == 2
+    fake_run.log.assert_any_call(
+        {
+            "image": unittest.mock.ANY,
+        },
+        step=0,
+    )
+    fake_run.log.assert_any_call(
+        {
+            "image": unittest.mock.ANY,
+        },
+        step=1,
+    )
+    if fake_run.log.call_args_list[0].kwargs["step"] == 0:
+        # Callback with logs of first step came in first
+        np.testing.assert_array_equal(
+            # Seems like using an io callback adds an extra leading dimension?
+            jnp.expand_dims(jax.device_get(_make_image(jax.random.key(0))), 0),
+            wandb_Image.call_args_list[0][0],
+        )
+        np.testing.assert_array_equal(
+            jnp.expand_dims(jax.device_get(_make_image(jax.random.key(1))), 0),
+            wandb_Image.call_args_list[1][0],
+        )
+    else:
+        raise NotImplementedError("BAD, metrics were logged in wrong order within a single run.")
+        #  Callback with logs of second step came in first?
+        # TODO: Wandb apparently doesn't support this!
+        np.testing.assert_array_equal(
+            jax.device_get(_make_image(jax.random.key(0))),
+            wandb_Image.call_args_list[0][0],
+        )
+        np.testing.assert_array_equal(
+            jax.device_get(_make_image(jax.random.key(1))),
+            wandb_Image.call_args_list[1][0],
+        )

--- a/parallel_wandb/utils.py
+++ b/parallel_wandb/utils.py
@@ -1,0 +1,69 @@
+import operator
+import typing
+from typing import Any, Iterable, Mapping, Sequence, TypeVar
+
+import numpy as np
+import optree
+
+T = TypeVar("T")
+K = TypeVar("K")
+V = TypeVar("V")
+type NestedSequence[T] = Sequence[T | NestedSequence[T]]
+type NestedMapping[K, V] = Mapping[K, V | NestedMapping[K, V]]
+
+
+def shape_begins_with(metric: np.typing.ArrayLike, prefix: tuple[int, ...]) -> bool:
+    """Returns `True` if `metric` has a shape that begins with `prefix`."""
+    if not hasattr(metric, "shape"):
+        return False
+    metric = typing.cast(np.typing.NDArray, metric)
+    return metric.shape[: len(prefix)] == prefix
+
+
+def slice[*Ts](
+    run_grid_shape: tuple[int, ...], *args: *Ts, strict: bool = True
+) -> Iterable[tuple[int, *Ts]]:
+    """Yields the slices of `args` for each run in the grid.
+
+    If `strict` is False and one of the args does not begin with the run_grid_shape, that arg
+    is duplicated for each run index. Otherwise an error will be raised when indexing the value.
+    """
+    num_runs = int(np.prod(run_grid_shape))
+    for run_index in range(num_runs):
+        indexing_tuple = np.unravel_index(run_index, run_grid_shape)
+        if strict:
+            args_i = optree.tree_map(
+                lambda v: operator.itemgetter(indexing_tuple)(v),
+                args,
+            )
+        else:
+            args_i = optree.tree_map(
+                lambda v: operator.itemgetter(indexing_tuple)(v)
+                if shape_begins_with(v, run_grid_shape)
+                else v,  # duplicate the metric if it doesn't have the right shape prefix?
+                args,
+            )
+        args_i = typing.cast(tuple[*Ts], tuple(args_i))
+        yield run_index, *args_i
+
+
+def is_tracer(v: Any) -> bool:
+    if "Tracer" in type(v).__name__:
+        return True
+    return False
+
+
+def get_step(
+    step: int | np.typing.ArrayLike, indexing_tuple: tuple[int, ...] | tuple[np.intp, ...]
+):
+    if isinstance(step, int) or not hasattr(step, "shape"):
+        return step
+    step = typing.cast(np.typing.NDArray, step)
+    if step.ndim == 0:
+        if is_tracer(step):
+            # Under jax.jit we can't call .item() on a tracer.
+            # The step will become an int once inside the io_callback.
+            return step
+        return step.item()
+    assert step.ndim == len(indexing_tuple)
+    return step[indexing_tuple]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dev = [
     "jax[cuda12]>=0.6.0; sys_platform == 'linux'",
     "rich>=14.0.0",
     "simple-parsing>=0.1.7",
+    "pillow>=11.2.1",
 ]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dev = [
     "rich>=14.0.0",
     "simple-parsing>=0.1.7",
     "pillow>=11.2.1",
+    "pytest-mock>=3.14.1",
 ]
 
 [tool.pytest.ini_options]

--- a/uv.lock
+++ b/uv.lock
@@ -839,6 +839,7 @@ dev = [
     { name = "jax", extra = ["cuda12"], marker = "sys_platform == 'linux'" },
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extra = ["python"] },
+    { name = "pillow" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "rich" },
@@ -861,6 +862,7 @@ dev = [
     { name = "jax", extras = ["cuda12"], marker = "sys_platform == 'linux'", specifier = ">=0.6.0" },
     { name = "mkdocs-material", specifier = ">=9.5.44" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=0.27.0" },
+    { name = "pillow", specifier = ">=11.2.1" },
     { name = "pytest", specifier = ">=8.3.3" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
     { name = "rich", specifier = ">=14.0.0" },
@@ -875,6 +877,47 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191 },
+]
+
+[[package]]
+name = "pillow"
+version = "11.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/cb/bb5c01fcd2a69335b86c22142b2bccfc3464087efb7fd382eee5ffc7fdf7/pillow-11.2.1.tar.gz", hash = "sha256:a64dd61998416367b7ef979b73d3a85853ba9bec4c2925f74e588879a58716b6", size = 47026707 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/40/052610b15a1b8961f52537cc8326ca6a881408bc2bdad0d852edeb6ed33b/pillow-11.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:78afba22027b4accef10dbd5eed84425930ba41b3ea0a86fa8d20baaf19d807f", size = 3190185 },
+    { url = "https://files.pythonhosted.org/packages/e5/7e/b86dbd35a5f938632093dc40d1682874c33dcfe832558fc80ca56bfcb774/pillow-11.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:78092232a4ab376a35d68c4e6d5e00dfd73454bd12b230420025fbe178ee3b0b", size = 3030306 },
+    { url = "https://files.pythonhosted.org/packages/a4/5c/467a161f9ed53e5eab51a42923c33051bf8d1a2af4626ac04f5166e58e0c/pillow-11.2.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:25a5f306095c6780c52e6bbb6109624b95c5b18e40aab1c3041da3e9e0cd3e2d", size = 4416121 },
+    { url = "https://files.pythonhosted.org/packages/62/73/972b7742e38ae0e2ac76ab137ca6005dcf877480da0d9d61d93b613065b4/pillow-11.2.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c7b29dbd4281923a2bfe562acb734cee96bbb129e96e6972d315ed9f232bef4", size = 4501707 },
+    { url = "https://files.pythonhosted.org/packages/e4/3a/427e4cb0b9e177efbc1a84798ed20498c4f233abde003c06d2650a6d60cb/pillow-11.2.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:3e645b020f3209a0181a418bffe7b4a93171eef6c4ef6cc20980b30bebf17b7d", size = 4522921 },
+    { url = "https://files.pythonhosted.org/packages/fe/7c/d8b1330458e4d2f3f45d9508796d7caf0c0d3764c00c823d10f6f1a3b76d/pillow-11.2.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:b2dbea1012ccb784a65349f57bbc93730b96e85b42e9bf7b01ef40443db720b4", size = 4612523 },
+    { url = "https://files.pythonhosted.org/packages/b3/2f/65738384e0b1acf451de5a573d8153fe84103772d139e1e0bdf1596be2ea/pillow-11.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:da3104c57bbd72948d75f6a9389e6727d2ab6333c3617f0a89d72d4940aa0443", size = 4587836 },
+    { url = "https://files.pythonhosted.org/packages/6a/c5/e795c9f2ddf3debb2dedd0df889f2fe4b053308bb59a3cc02a0cd144d641/pillow-11.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:598174aef4589af795f66f9caab87ba4ff860ce08cd5bb447c6fc553ffee603c", size = 4669390 },
+    { url = "https://files.pythonhosted.org/packages/96/ae/ca0099a3995976a9fce2f423166f7bff9b12244afdc7520f6ed38911539a/pillow-11.2.1-cp312-cp312-win32.whl", hash = "sha256:1d535df14716e7f8776b9e7fee118576d65572b4aad3ed639be9e4fa88a1cad3", size = 2332309 },
+    { url = "https://files.pythonhosted.org/packages/7c/18/24bff2ad716257fc03da964c5e8f05d9790a779a8895d6566e493ccf0189/pillow-11.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:14e33b28bf17c7a38eede290f77db7c664e4eb01f7869e37fa98a5aa95978941", size = 2676768 },
+    { url = "https://files.pythonhosted.org/packages/da/bb/e8d656c9543276517ee40184aaa39dcb41e683bca121022f9323ae11b39d/pillow-11.2.1-cp312-cp312-win_arm64.whl", hash = "sha256:21e1470ac9e5739ff880c211fc3af01e3ae505859392bf65458c224d0bf283eb", size = 2415087 },
+    { url = "https://files.pythonhosted.org/packages/36/9c/447528ee3776e7ab8897fe33697a7ff3f0475bb490c5ac1456a03dc57956/pillow-11.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fdec757fea0b793056419bca3e9932eb2b0ceec90ef4813ea4c1e072c389eb28", size = 3190098 },
+    { url = "https://files.pythonhosted.org/packages/b5/09/29d5cd052f7566a63e5b506fac9c60526e9ecc553825551333e1e18a4858/pillow-11.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:b0e130705d568e2f43a17bcbe74d90958e8a16263868a12c3e0d9c8162690830", size = 3030166 },
+    { url = "https://files.pythonhosted.org/packages/71/5d/446ee132ad35e7600652133f9c2840b4799bbd8e4adba881284860da0a36/pillow-11.2.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7bdb5e09068332578214cadd9c05e3d64d99e0e87591be22a324bdbc18925be0", size = 4408674 },
+    { url = "https://files.pythonhosted.org/packages/69/5f/cbe509c0ddf91cc3a03bbacf40e5c2339c4912d16458fcb797bb47bcb269/pillow-11.2.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d189ba1bebfbc0c0e529159631ec72bb9e9bc041f01ec6d3233d6d82eb823bc1", size = 4496005 },
+    { url = "https://files.pythonhosted.org/packages/f9/b3/dd4338d8fb8a5f312021f2977fb8198a1184893f9b00b02b75d565c33b51/pillow-11.2.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:191955c55d8a712fab8934a42bfefbf99dd0b5875078240943f913bb66d46d9f", size = 4518707 },
+    { url = "https://files.pythonhosted.org/packages/13/eb/2552ecebc0b887f539111c2cd241f538b8ff5891b8903dfe672e997529be/pillow-11.2.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:ad275964d52e2243430472fc5d2c2334b4fc3ff9c16cb0a19254e25efa03a155", size = 4610008 },
+    { url = "https://files.pythonhosted.org/packages/72/d1/924ce51bea494cb6e7959522d69d7b1c7e74f6821d84c63c3dc430cbbf3b/pillow-11.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:750f96efe0597382660d8b53e90dd1dd44568a8edb51cb7f9d5d918b80d4de14", size = 4585420 },
+    { url = "https://files.pythonhosted.org/packages/43/ab/8f81312d255d713b99ca37479a4cb4b0f48195e530cdc1611990eb8fd04b/pillow-11.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:fe15238d3798788d00716637b3d4e7bb6bde18b26e5d08335a96e88564a36b6b", size = 4667655 },
+    { url = "https://files.pythonhosted.org/packages/94/86/8f2e9d2dc3d308dfd137a07fe1cc478df0a23d42a6c4093b087e738e4827/pillow-11.2.1-cp313-cp313-win32.whl", hash = "sha256:3fe735ced9a607fee4f481423a9c36701a39719252a9bb251679635f99d0f7d2", size = 2332329 },
+    { url = "https://files.pythonhosted.org/packages/6d/ec/1179083b8d6067a613e4d595359b5fdea65d0a3b7ad623fee906e1b3c4d2/pillow-11.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:74ee3d7ecb3f3c05459ba95eed5efa28d6092d751ce9bf20e3e253a4e497e691", size = 2676388 },
+    { url = "https://files.pythonhosted.org/packages/23/f1/2fc1e1e294de897df39fa8622d829b8828ddad938b0eaea256d65b84dd72/pillow-11.2.1-cp313-cp313-win_arm64.whl", hash = "sha256:5119225c622403afb4b44bad4c1ca6c1f98eed79db8d3bc6e4e160fc6339d66c", size = 2414950 },
+    { url = "https://files.pythonhosted.org/packages/c4/3e/c328c48b3f0ead7bab765a84b4977acb29f101d10e4ef57a5e3400447c03/pillow-11.2.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:8ce2e8411c7aaef53e6bb29fe98f28cd4fbd9a1d9be2eeea434331aac0536b22", size = 3192759 },
+    { url = "https://files.pythonhosted.org/packages/18/0e/1c68532d833fc8b9f404d3a642991441d9058eccd5606eab31617f29b6d4/pillow-11.2.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:9ee66787e095127116d91dea2143db65c7bb1e232f617aa5957c0d9d2a3f23a7", size = 3033284 },
+    { url = "https://files.pythonhosted.org/packages/b7/cb/6faf3fb1e7705fd2db74e070f3bf6f88693601b0ed8e81049a8266de4754/pillow-11.2.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9622e3b6c1d8b551b6e6f21873bdcc55762b4b2126633014cea1803368a9aa16", size = 4445826 },
+    { url = "https://files.pythonhosted.org/packages/07/94/8be03d50b70ca47fb434a358919d6a8d6580f282bbb7af7e4aa40103461d/pillow-11.2.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:63b5dff3a68f371ea06025a1a6966c9a1e1ee452fc8020c2cd0ea41b83e9037b", size = 4527329 },
+    { url = "https://files.pythonhosted.org/packages/fd/a4/bfe78777076dc405e3bd2080bc32da5ab3945b5a25dc5d8acaa9de64a162/pillow-11.2.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:31df6e2d3d8fc99f993fd253e97fae451a8db2e7207acf97859732273e108406", size = 4549049 },
+    { url = "https://files.pythonhosted.org/packages/65/4d/eaf9068dc687c24979e977ce5677e253624bd8b616b286f543f0c1b91662/pillow-11.2.1-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:062b7a42d672c45a70fa1f8b43d1d38ff76b63421cbbe7f88146b39e8a558d91", size = 4635408 },
+    { url = "https://files.pythonhosted.org/packages/1d/26/0fd443365d9c63bc79feb219f97d935cd4b93af28353cba78d8e77b61719/pillow-11.2.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:4eb92eca2711ef8be42fd3f67533765d9fd043b8c80db204f16c8ea62ee1a751", size = 4614863 },
+    { url = "https://files.pythonhosted.org/packages/49/65/dca4d2506be482c2c6641cacdba5c602bc76d8ceb618fd37de855653a419/pillow-11.2.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f91ebf30830a48c825590aede79376cb40f110b387c17ee9bd59932c961044f9", size = 4692938 },
+    { url = "https://files.pythonhosted.org/packages/b3/92/1ca0c3f09233bd7decf8f7105a1c4e3162fb9142128c74adad0fb361b7eb/pillow-11.2.1-cp313-cp313t-win32.whl", hash = "sha256:e0b55f27f584ed623221cfe995c912c61606be8513bfa0e07d2c674b4516d9dd", size = 2335774 },
+    { url = "https://files.pythonhosted.org/packages/a5/ac/77525347cb43b83ae905ffe257bbe2cc6fd23acb9796639a1f56aa59d191/pillow-11.2.1-cp313-cp313t-win_amd64.whl", hash = "sha256:36d6b82164c39ce5482f649b437382c0fb2395eabc1e2b1702a6deb8ad647d6e", size = 2681895 },
+    { url = "https://files.pythonhosted.org/packages/67/32/32dc030cfa91ca0fc52baebbba2e009bb001122a1daa8b6a79ad830b38d3/pillow-11.2.1-cp313-cp313t-win_arm64.whl", hash = "sha256:225c832a13326e34f212d2072982bb1adb210e0cc0b153e688743018c94a2681", size = 2417234 },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -842,6 +842,7 @@ dev = [
     { name = "pillow" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-mock" },
     { name = "rich" },
     { name = "simple-parsing" },
     { name = "uv-dynamic-versioning" },
@@ -865,6 +866,7 @@ dev = [
     { name = "pillow", specifier = ">=11.2.1" },
     { name = "pytest", specifier = ">=8.3.3" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
+    { name = "pytest-mock", specifier = ">=3.14.1" },
     { name = "rich", specifier = ">=14.0.0" },
     { name = "simple-parsing", specifier = ">=0.1.7" },
     { name = "uv-dynamic-versioning", specifier = ">=0.2.0" },
@@ -1072,6 +1074,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/25/69/5f1e57f6c5a39f81411b550027bf72842c4567ff5fd572bed1edc9e4b5d9/pytest_cov-6.1.1.tar.gz", hash = "sha256:46935f7aaefba760e716c2ebfbe1c216240b9592966e7da99ea8292d4d3e2a0a", size = 66857 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/28/d0/def53b4a790cfb21483016430ed828f64830dd981ebe1089971cd10cab25/pytest_cov-6.1.1-py3-none-any.whl", hash = "sha256:bddf29ed2d0ab6f4df17b4c55b0a657287db8684af9c42ea546b21b1041b3dde", size = 23841 },
+]
+
+[[package]]
+name = "pytest-mock"
+version = "3.14.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/28/67172c96ba684058a4d24ffe144d64783d2a270d0af0d9e792737bddc75c/pytest_mock-3.14.1.tar.gz", hash = "sha256:159e9edac4c451ce77a5cdb9fc5d1100708d2dd4ba3c3df572f14097351af80e", size = 33241 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/05/77b60e520511c53d1c1ca75f1930c7dd8e971d0c4379b7f4b3f9644685ba/pytest_mock-3.14.1-py3-none-any.whl", hash = "sha256:178aefcd11307d874b4cd3100344e7e2d888d9791a6a1d9bfe90fbc1b74fd1d0", size = 9923 },
 ]
 
 [[package]]


### PR DESCRIPTION
Improve robustness of `wandb_log` and add tests for logging metrics across multiple runs. Introduce new submodules for better organization and include tests for the `jax_mnist` example.